### PR TITLE
fix: expand-file-name: Wrong type argument: stringp, nil

### DIFF
--- a/org-zettel-ref-mode.el
+++ b/org-zettel-ref-mode.el
@@ -378,8 +378,10 @@ This should be a string that can be passed to `kbd'."
     (org-zettel-ref-mode-disable)))
 
 (defcustom org-zettel-ref-python-script
-  (expand-file-name "conversion_script.py"
-                    (file-name-directory (locate-library "org-zettel-ref-mode")))
+  (let ((lib-path (locate-library "org-zettel-ref-mode")))
+    (expand-file-name "conversion_script.py"
+                      (or (and lib-path (file-name-directory lib-path))
+                          default-directory)))
   "Path to the Python conversion script."
   :type 'file
   :group 'org-zettel-ref)


### PR DESCRIPTION
fix use emacs basic test the package.
On package dir test:
```shell
emacs -q -l org-zettel-ref-mode.el
```
Find file `convert-to-org.py` fail.

Fix find file convert-to-org.py on current package directory if no org-zettel-ref-mode directory.